### PR TITLE
use the node module without static reference

### DIFF
--- a/lib/privnote-common.js
+++ b/lib/privnote-common.js
@@ -1,7 +1,7 @@
 // https://privnote.com/static-ffcdb2d/js-min/common.js
 // Privnote Ver. 1.1-24-gffcdb2d / 2016-09-27 | © Ikatu - http://www.ikatu.us/privnote.html
 
-var GibberishAES = require("../node_modules/gibberish-aes/dist/gibberish-aes-1.0.0");
+var GibberishAES = require("gibberish-aes/dist/gibberish-aes-1.0.0");
 
 var common = module.exports = function() {
     var auto_pass_length = 9;


### PR DESCRIPTION
using the node module in that manner breaks the lib when installed using `yarn` - the libraries aren't always in the expected file-system configuration, but will be found correctly by both yarn and NPM when referenced in this way.